### PR TITLE
[MENU] feat: 메뉴 엔티티 정의

### DIFF
--- a/src/main/java/com/asgs/allimi/menu/domain/Menu.java
+++ b/src/main/java/com/asgs/allimi/menu/domain/Menu.java
@@ -1,0 +1,56 @@
+package com.asgs.allimi.menu.domain;
+
+import com.asgs.allimi.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Menu extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(length = 1000)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MenuCategory category;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Column(nullable = false)
+    private int stockCount;
+
+    private int discount;
+
+    @ColumnDefault("0")
+    private int soldCount;
+
+    @ColumnDefault("true")
+    @Column(nullable = false)
+    private boolean onSale;
+
+    @ColumnDefault("false")
+    @Column(nullable = false)
+    private boolean isAbleBook;
+
+    @Builder
+    public Menu(String name, String description, MenuCategory category, int price, int stockCount){
+        this.name = name;
+        this.description = description;
+        this.category = category;
+        this.price = price;
+        this.stockCount = stockCount;
+    }
+}

--- a/src/main/java/com/asgs/allimi/menu/domain/MenuCategory.java
+++ b/src/main/java/com/asgs/allimi/menu/domain/MenuCategory.java
@@ -1,0 +1,12 @@
+package com.asgs.allimi.menu.domain;
+
+public enum MenuCategory {
+    MADE_BEVERAGE,
+    DRINK,
+    FOOD,
+    SNACK,
+    ICE_CREAM,
+    BREAD,
+    BAKERY,
+    ETC
+}

--- a/src/main/java/com/asgs/allimi/menu/domain/MenuImage.java
+++ b/src/main/java/com/asgs/allimi/menu/domain/MenuImage.java
@@ -1,0 +1,27 @@
+package com.asgs.allimi.menu.domain;
+
+import com.asgs.allimi.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MenuImage extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id")
+    private Menu menu;
+
+    @Column(nullable = false)
+    private String path;
+
+}


### PR DESCRIPTION
## Related Issue
close #10 

- 기존에는 카테고리를 테이블화하여 관리했지만 최신 카테고리 업데이트에 의해 Enum으로 관리하기에 적합하다고 판단하여 Enum으로 변경
- Menu Image 엔티티 정의
  - 기존 설계에서는 사용처(썸네일, 메인 등)에 대한 컬럼을 정의했지만 path의 prefix로 쿼리하는 방식으로 사용해보고자 삭제
  - 연관관계 없이 FK만 두는 방식을 사용하다가 연관관계 기능 사용
- Menu 엔티티 정의
  - 기존 isBest, isNew 컬럼을 삭제하고, 조회 API에서 특정한 기준으로 가져오게끔 설계하였기에 삭제
  - BEST 메뉴: 특정 기간 동안 판매량이 많은 상품
  - NEW 메뉴: 현 시점으로부터 생성된지 얼마되지 않은 상품
  - discount 필드를 정수로 정의