### PR TITLE
[COMMON] feat: 글로벌 예외 처리 핸들러 정의

### DIFF
--- a/src/main/java/com/asgs/allimi/common/exception/CustomClientException.java
+++ b/src/main/java/com/asgs/allimi/common/exception/CustomClientException.java
@@ -1,0 +1,24 @@
+package com.asgs.allimi.common.exception;
+
+import com.asgs.allimi.common.response.ResultCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomClientException extends RuntimeException{
+
+    private final HttpStatus httpStatus;
+    private final ResultCode resultCode;
+    private final String resultMessage;
+
+    public CustomClientException(HttpStatus httpStatus, ResultCode resultCode){
+        this(httpStatus, resultCode, resultCode.getMessage());
+    }
+
+    public CustomClientException(HttpStatus httpStatus, ResultCode resultCode, String resultMessage){
+        super(resultMessage);
+        this.httpStatus = httpStatus;
+        this.resultCode = resultCode;
+        this.resultMessage = resultMessage;
+    }
+}

--- a/src/main/java/com/asgs/allimi/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/asgs/allimi/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.asgs.allimi.common.exception;
+
+import com.asgs.allimi.common.response.ResponseForm;
+import com.asgs.allimi.common.response.ResultCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ResponseForm<Void>> handleInternalErrorException(Exception e, HttpServletRequest request){
+        log.error("[서버 에러] at {}", request.getRequestURI(), e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ResponseForm<>(ResultCode.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(CustomClientException.class)
+    protected ResponseEntity<ResponseForm<Void>> handleCustomClientException(CustomClientException e, HttpServletRequest request){
+        log.warn("[클라이언트 에러] at {}", request.getRequestURI(), e);
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(new ResponseForm<>(e.getResultCode()));
+    }
+}

--- a/src/main/java/com/asgs/allimi/common/response/ResponseForm.java
+++ b/src/main/java/com/asgs/allimi/common/response/ResponseForm.java
@@ -1,0 +1,33 @@
+package com.asgs.allimi.common.response;
+
+import lombok.Data;
+
+@Data
+public class ResponseForm<T> {
+
+    private StatusResponse statusResponse = new StatusResponse(ResultCode.OK);
+    private final T data;
+
+    public ResponseForm(){
+        this.data = null;
+    }
+
+    public ResponseForm(T data){ // success
+        this.data = data;
+    }
+
+    public ResponseForm(T data, ResultCode resultCode){
+        this.data = data;
+        this.statusResponse = new StatusResponse(resultCode);
+    }
+
+    public ResponseForm(ResultCode resultCode){ // failure
+        this();
+        this.statusResponse = new StatusResponse(resultCode);
+    }
+
+    public ResponseForm(String resultCode, String resultMessage){
+        this();
+        this.statusResponse = new StatusResponse(resultCode, resultMessage);
+    }
+}

--- a/src/main/java/com/asgs/allimi/common/response/ResultCode.java
+++ b/src/main/java/com/asgs/allimi/common/response/ResultCode.java
@@ -1,0 +1,22 @@
+package com.asgs.allimi.common.response;
+
+import lombok.Getter;
+
+@Getter
+public enum ResultCode {
+
+    // 정상 처리
+    OK("GS0000", "요청 정상"),
+    CREATED("GS0001", "데이터 정상 생성 완료"),
+
+    // 서버 에러
+    INTERNAL_SERVER_ERROR("GS1000", "서버 내부 에러 발생"),
+    ;
+    private final String code;
+    private final String message;
+
+    ResultCode(String code, String message){
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/asgs/allimi/common/response/StatusResponse.java
+++ b/src/main/java/com/asgs/allimi/common/response/StatusResponse.java
@@ -1,0 +1,17 @@
+package com.asgs.allimi.common.response;
+
+import lombok.Getter;
+
+@Getter
+public class StatusResponse {
+    private final String resultCode;
+    private final String resultMessage;
+
+    public StatusResponse(ResultCode resultCode){
+        this(resultCode.getCode(), resultCode.getMessage());
+    }
+    public StatusResponse(String resultCode, String resultMessage){
+        this.resultCode = resultCode;
+        this.resultMessage = resultMessage;
+    }
+}


### PR DESCRIPTION
## Related Issue
close #8 

- 공통 응답 폼 클래스 정의
  - 요청 정상 시 제네릭으로 데이터 전달; 성공 상태 코드도 파라미터로 전달
    - 기본 HttpStatus 코드는 200으로 전달
    - 만약 201 사용하고 싶다면 컨트롤러 핸들러 메소드에 ResponseStatus 어노테이션으로 명시하게끔 하며 커스텀 상태 코드도 변경
  - 요청 실패 시 커스텀 클라이언트 에러 상태 코드 전달
- 상태 코드 정의
  - 전반적인 2xx, 4xx, 5xx 코드에 대한 구체적인 결과 정의
- 글로벌 예외 핸들러 정의
  - 4xx, 5xx 에러에 대한 핸들러 정의