### PR TITLE
[MENU] feat: 메뉴 생성 API 구현

### DIFF
--- a/src/main/java/com/asgs/allimi/AllimiApplication.java
+++ b/src/main/java/com/asgs/allimi/AllimiApplication.java
@@ -2,8 +2,10 @@ package com.asgs.allimi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class AllimiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/asgs/allimi/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/asgs/allimi/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,16 +15,23 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ResponseForm<Void>> handleInternalErrorException(Exception e, HttpServletRequest request){
+    protected ResponseEntity<ResponseForm<Void>> handleInternalErrorException(Exception e, HttpServletRequest request) {
         log.error("[서버 에러] at {}", request.getRequestURI(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ResponseForm<>(ResultCode.INTERNAL_SERVER_ERROR));
     }
 
     @ExceptionHandler(CustomClientException.class)
-    protected ResponseEntity<ResponseForm<Void>> handleCustomClientException(CustomClientException e, HttpServletRequest request){
+    protected ResponseEntity<ResponseForm<Void>> handleCustomClientException(CustomClientException e, HttpServletRequest request) {
         log.warn("[클라이언트 에러] at {}", request.getRequestURI(), e);
         return ResponseEntity.status(e.getHttpStatus())
                 .body(new ResponseForm<>(e.getResultCode()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ResponseForm<Void>> handlerMethodArgumentException(MethodArgumentNotValidException e, HttpServletRequest request) {
+        log.warn("[클라이언트 에러] at {}", request.getRequestURI(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ResponseForm<>(ResultCode.INVALID_INPUT));
     }
 }

--- a/src/main/java/com/asgs/allimi/common/response/ResultCode.java
+++ b/src/main/java/com/asgs/allimi/common/response/ResultCode.java
@@ -11,11 +11,16 @@ public enum ResultCode {
 
     // 서버 에러
     INTERNAL_SERVER_ERROR("GS1000", "서버 내부 에러 발생"),
-    ;
+    INVALID_INPUT("GS1001", "요청 입력 값이 유효하지 않습니다."),
+
+    // 메뉴 클라이언트 에러
+    INVALID_INPUT_STOCK_QUANTITY("GS2000", "유효한 재고 수량이 아닙니다."),
+    INVALID_INPUT_MENU_PRICE("GS2001", "유효하지 않은 상품 가격입니다."),
+    INVALID_INPUT_DISCOUNT("GS2001", "유효하지 않은 상품 할인률입니다.");
     private final String code;
     private final String message;
 
-    ResultCode(String code, String message){
+    ResultCode(String code, String message) {
         this.code = code;
         this.message = message;
     }

--- a/src/main/java/com/asgs/allimi/config/SecurityConfig.java
+++ b/src/main/java/com/asgs/allimi/config/SecurityConfig.java
@@ -28,8 +28,8 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
 
                 .authorizeHttpRequests(requests -> requests
-                        .requestMatchers("/api/v1/auth/**").permitAll()
-                        .anyRequest().authenticated()
+                        .requestMatchers("/**").permitAll()
+//                        .anyRequest().authenticated()
                 );
         return httpSecurity.build();
     }

--- a/src/main/java/com/asgs/allimi/menu/controller/MenuCommandController.java
+++ b/src/main/java/com/asgs/allimi/menu/controller/MenuCommandController.java
@@ -1,0 +1,29 @@
+package com.asgs.allimi.menu.controller;
+
+import com.asgs.allimi.common.response.ResponseForm;
+import com.asgs.allimi.menu.dto.MenuCommandDto;
+import com.asgs.allimi.menu.service.MenuCommandService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/menu")
+// TODO: 어드민 권한 추가
+public class MenuCommandController {
+
+    private final MenuCommandService menuCommandService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ResponseForm<Map<String, Long>> createMenu(@RequestBody @Valid MenuCommandDto.Create create) {
+        Map<String, Long> response = new HashMap<>();
+        response.put("menuId", menuCommandService.createMenu(create));
+        return new ResponseForm<>(response);
+    }
+}

--- a/src/main/java/com/asgs/allimi/menu/domain/Menu.java
+++ b/src/main/java/com/asgs/allimi/menu/domain/Menu.java
@@ -1,6 +1,7 @@
 package com.asgs.allimi.menu.domain;
 
 import com.asgs.allimi.common.BaseEntity;
+import com.asgs.allimi.menu.dto.MenuCommandDto;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,19 +42,17 @@ public class Menu extends BaseEntity {
     @ColumnDefault("0")
     private int soldCount;
 
-    @ColumnDefault("true")
     @Column(nullable = false)
-    private boolean onSale;
+    private boolean onSale = true;
 
-    @ColumnDefault("false")
     @Column(nullable = false)
-    private boolean isAbleBook;
+    private boolean isAbleBook = false;
 
     @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MenuOption> menuOptions = new ArrayList<>();
 
     @Builder
-    public Menu(String name, String description, MenuCategory category, int price, int stockQuantity, int discount, boolean isAbleBook){
+    public Menu(String name, String description, MenuCategory category, int price, int stockQuantity, int discount, boolean isAbleBook) {
         this.name = name;
         this.description = description;
         this.category = category;
@@ -63,7 +62,19 @@ public class Menu extends BaseEntity {
         this.isAbleBook = isAbleBook;
     }
 
-    public void updateMenuOptions(List<MenuOption> menuOptions){
+    public static Menu from(MenuCommandDto.Request request) {
+        return Menu.builder()
+                .name(request.getName())
+                .description(request.getDescription())
+                .price(request.getPrice())
+                .stockQuantity(request.getStockQuantity())
+                .discount(request.getDiscount())
+                .category(request.getMenuCategory())
+                .isAbleBook(request.isAbleBook())
+                .build();
+    }
+
+    public void updateMenuOptions(List<MenuOption> menuOptions) {
         this.menuOptions = menuOptions;
     }
 }

--- a/src/main/java/com/asgs/allimi/menu/domain/Menu.java
+++ b/src/main/java/com/asgs/allimi/menu/domain/Menu.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -14,6 +17,7 @@ public class Menu extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "menu_id")
     private Long id;
 
     @Column(nullable = false, length = 50)
@@ -45,6 +49,9 @@ public class Menu extends BaseEntity {
     @Column(nullable = false)
     private boolean isAbleBook;
 
+    @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MenuOption> menuOptions = new ArrayList<>();
+
     @Builder
     public Menu(String name, String description, MenuCategory category, int price, int stockQuantity){
         this.name = name;
@@ -52,5 +59,9 @@ public class Menu extends BaseEntity {
         this.category = category;
         this.price = price;
         this.stockQuantity = stockQuantity;
+    }
+
+    public void updateMenuOptions(List<MenuOption> menuOptions){
+        this.menuOptions = menuOptions;
     }
 }

--- a/src/main/java/com/asgs/allimi/menu/domain/Menu.java
+++ b/src/main/java/com/asgs/allimi/menu/domain/Menu.java
@@ -30,7 +30,7 @@ public class Menu extends BaseEntity {
     private int price;
 
     @Column(nullable = false)
-    private int stockCount;
+    private int stockQuantity;
 
     private int discount;
 
@@ -46,11 +46,11 @@ public class Menu extends BaseEntity {
     private boolean isAbleBook;
 
     @Builder
-    public Menu(String name, String description, MenuCategory category, int price, int stockCount){
+    public Menu(String name, String description, MenuCategory category, int price, int stockQuantity){
         this.name = name;
         this.description = description;
         this.category = category;
         this.price = price;
-        this.stockCount = stockCount;
+        this.stockQuantity = stockQuantity;
     }
 }

--- a/src/main/java/com/asgs/allimi/menu/domain/Menu.java
+++ b/src/main/java/com/asgs/allimi/menu/domain/Menu.java
@@ -62,15 +62,15 @@ public class Menu extends BaseEntity {
         this.isAbleBook = isAbleBook;
     }
 
-    public static Menu from(MenuCommandDto.Request request) {
+    public static Menu from(MenuCommandDto.Create create) {
         return Menu.builder()
-                .name(request.getName())
-                .description(request.getDescription())
-                .price(request.getPrice())
-                .stockQuantity(request.getStockQuantity())
-                .discount(request.getDiscount())
-                .category(request.getMenuCategory())
-                .isAbleBook(request.isAbleBook())
+                .name(create.getName())
+                .description(create.getDescription())
+                .price(create.getPrice())
+                .stockQuantity(create.getStockQuantity())
+                .discount(create.getDiscount())
+                .category(create.getMenuCategory())
+                .isAbleBook(create.isAbleBook())
                 .build();
     }
 

--- a/src/main/java/com/asgs/allimi/menu/domain/Menu.java
+++ b/src/main/java/com/asgs/allimi/menu/domain/Menu.java
@@ -53,12 +53,14 @@ public class Menu extends BaseEntity {
     private List<MenuOption> menuOptions = new ArrayList<>();
 
     @Builder
-    public Menu(String name, String description, MenuCategory category, int price, int stockQuantity){
+    public Menu(String name, String description, MenuCategory category, int price, int stockQuantity, int discount, boolean isAbleBook){
         this.name = name;
         this.description = description;
         this.category = category;
         this.price = price;
+        this.discount = discount;
         this.stockQuantity = stockQuantity;
+        this.isAbleBook = isAbleBook;
     }
 
     public void updateMenuOptions(List<MenuOption> menuOptions){

--- a/src/main/java/com/asgs/allimi/menu/domain/MenuDetailOption.java
+++ b/src/main/java/com/asgs/allimi/menu/domain/MenuDetailOption.java
@@ -16,10 +16,11 @@ public class MenuDetailOption extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "menu_detail_option_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "id")
+    @JoinColumn(name = "menu_option_id")
     private MenuOption menuOption;
 
     @Column(nullable = false, length = 20)

--- a/src/main/java/com/asgs/allimi/menu/domain/MenuImage.java
+++ b/src/main/java/com/asgs/allimi/menu/domain/MenuImage.java
@@ -15,10 +15,11 @@ import lombok.NoArgsConstructor;
 public class MenuImage extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "menu_image_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "id")
+    @JoinColumn(name = "menu_id")
     private Menu menu;
 
     @Column(nullable = false)

--- a/src/main/java/com/asgs/allimi/menu/domain/MenuOption.java
+++ b/src/main/java/com/asgs/allimi/menu/domain/MenuOption.java
@@ -7,6 +7,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -16,12 +19,16 @@ public class MenuOption extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "menu_option_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "id")
+    @JoinColumn(name = "menu_id")
     private Menu menu;
 
     @Column(nullable = false, length = 20)
     private String title;
+
+    @OneToMany(mappedBy = "menuOption", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MenuDetailOption> menuDetailOptions = new ArrayList<>();
 }

--- a/src/main/java/com/asgs/allimi/menu/dto/MenuCommandDto.java
+++ b/src/main/java/com/asgs/allimi/menu/dto/MenuCommandDto.java
@@ -1,0 +1,35 @@
+package com.asgs.allimi.menu.dto;
+
+import com.asgs.allimi.menu.domain.MenuCategory;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class MenuCommandDto {
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Create {
+        @NotBlank
+        private String name;
+        private String description;
+        @NotNull
+        private MenuCategory menuCategory;
+        private int price;
+        private int stockQuantity;
+        private int discount;
+        @JsonProperty("isAbleBook")
+        private boolean isAbleBook;
+        private boolean onSale;
+        private List<MenuOptionCommandDto.Create> options;
+    }
+
+}

--- a/src/main/java/com/asgs/allimi/menu/dto/MenuDetailOptionCommandDto.java
+++ b/src/main/java/com/asgs/allimi/menu/dto/MenuDetailOptionCommandDto.java
@@ -1,0 +1,17 @@
+package com.asgs.allimi.menu.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class MenuDetailOptionCommandDto {
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Create {
+        private String choice;
+        private int price;
+    }
+}

--- a/src/main/java/com/asgs/allimi/menu/dto/MenuOptionCommandDto.java
+++ b/src/main/java/com/asgs/allimi/menu/dto/MenuOptionCommandDto.java
@@ -1,0 +1,20 @@
+package com.asgs.allimi.menu.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class MenuOptionCommandDto {
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Create {
+        private String title;
+        private List<MenuDetailOptionCommandDto.Create> detailOptions;
+    }
+}

--- a/src/main/java/com/asgs/allimi/menu/repository/MenuDetailOptionRepository.java
+++ b/src/main/java/com/asgs/allimi/menu/repository/MenuDetailOptionRepository.java
@@ -1,0 +1,7 @@
+package com.asgs.allimi.menu.repository;
+
+import com.asgs.allimi.menu.domain.MenuDetailOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuDetailOptionRepository extends JpaRepository<MenuDetailOption, Long> {
+}

--- a/src/main/java/com/asgs/allimi/menu/repository/MenuImageRepository.java
+++ b/src/main/java/com/asgs/allimi/menu/repository/MenuImageRepository.java
@@ -1,0 +1,7 @@
+package com.asgs.allimi.menu.repository;
+
+import com.asgs.allimi.menu.domain.MenuImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuImageRepository extends JpaRepository<MenuImage, Long> {
+}

--- a/src/main/java/com/asgs/allimi/menu/repository/MenuOptionRepository.java
+++ b/src/main/java/com/asgs/allimi/menu/repository/MenuOptionRepository.java
@@ -1,0 +1,7 @@
+package com.asgs.allimi.menu.repository;
+
+import com.asgs.allimi.menu.domain.MenuOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuOptionRepository extends JpaRepository<MenuOption, Long> {
+}

--- a/src/main/java/com/asgs/allimi/menu/repository/MenuRepository.java
+++ b/src/main/java/com/asgs/allimi/menu/repository/MenuRepository.java
@@ -1,0 +1,7 @@
+package com.asgs.allimi.menu.repository;
+
+import com.asgs.allimi.menu.domain.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+}

--- a/src/main/java/com/asgs/allimi/menu/service/MenuCommandService.java
+++ b/src/main/java/com/asgs/allimi/menu/service/MenuCommandService.java
@@ -1,0 +1,57 @@
+package com.asgs.allimi.menu.service;
+
+import com.asgs.allimi.common.exception.CustomClientException;
+import com.asgs.allimi.menu.domain.Menu;
+import com.asgs.allimi.menu.dto.MenuCommandDto;
+import com.asgs.allimi.menu.repository.MenuRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import static com.asgs.allimi.common.response.ResultCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MenuCommandService {
+    private final MenuRepository menuRepository;
+    private final MenuOptionCommandService menuOptionCommandService;
+
+    public Long createMenu(MenuCommandDto.Create create) {
+        validateInput(create);
+
+        Menu menu = Menu.from(create);
+        // TODO: 이미지 처리
+        if (create.getOptions() != null && !create.getOptions().isEmpty()) {
+            menu.updateMenuOptions(menuOptionCommandService.convertMenuOption(create.getOptions()));
+        }
+        return menuRepository.save(menu).getId();
+    }
+
+    private void validateInput(MenuCommandDto.Create create) {
+        if (create.getMenuCategory() == null) {
+            throw new CustomClientException(HttpStatus.BAD_REQUEST, INVALID_INPUT);
+        }
+
+        if (!isValidAmount(create.getStockQuantity())) {
+            throw new CustomClientException(HttpStatus.BAD_REQUEST, INVALID_INPUT_STOCK_QUANTITY);
+        }
+
+        if (!isValidAmount(create.getPrice())) {
+            throw new CustomClientException(HttpStatus.BAD_REQUEST, INVALID_INPUT_MENU_PRICE);
+        }
+
+        if (!isIncludeRange(create.getDiscount())) {
+            throw new CustomClientException(HttpStatus.BAD_REQUEST, INVALID_INPUT_DISCOUNT);
+        }
+    }
+
+    private boolean isValidAmount(int amount) {
+        return amount >= 0;
+    }
+
+    private boolean isIncludeRange(int amount) {
+        return amount >= 0 && amount <= 100;
+    }
+}

--- a/src/main/java/com/asgs/allimi/menu/service/MenuOptionCommandService.java
+++ b/src/main/java/com/asgs/allimi/menu/service/MenuOptionCommandService.java
@@ -1,0 +1,32 @@
+package com.asgs.allimi.menu.service;
+
+import com.asgs.allimi.menu.domain.MenuDetailOption;
+import com.asgs.allimi.menu.domain.MenuOption;
+import com.asgs.allimi.menu.dto.MenuOptionCommandDto;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MenuOptionCommandService {
+
+    public List<MenuOption> convertMenuOption(List<MenuOptionCommandDto.Create> options){
+        return options.stream()
+                .map(option -> {
+                    List<MenuDetailOption> detailOptions = option.getDetailOptions().stream()
+                            .map(detail -> MenuDetailOption.builder()
+                                    .price(detail.getPrice())
+                                    .choice(detail.getChoice())
+                                    .build())
+                            .toList();
+                    return MenuOption.builder()
+                            .title(option.getTitle())
+                            .menuDetailOptions(detailOptions)
+                            .build();
+                }).toList();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     url: jdbc:mysql://127.0.0.1:3306/allimi?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: root
-    password: 0000
+    password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:

--- a/src/test/java/com/asgs/allimi/menu/controller/MenuCommandControllerTest.java
+++ b/src/test/java/com/asgs/allimi/menu/controller/MenuCommandControllerTest.java
@@ -1,0 +1,76 @@
+package com.asgs.allimi.menu.controller;
+
+import com.asgs.allimi.common.response.ResultCode;
+import com.asgs.allimi.menu.domain.MenuCategory;
+import com.asgs.allimi.menu.dto.MenuCommandDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class MenuCommandControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    private static final String BASE_URI = "/api/v1/menu";
+
+    @Test
+    @DisplayName("정상 데이터에 대한 메뉴 생성에 성공한다.")
+    void createMenu() throws Exception{
+        MenuCommandDto.Create create = MenuCommandDto.Create.builder()
+                .name("상품1")
+                .description("설명1")
+                .price(1000)
+                .stockQuantity(15)
+                .menuCategory(MenuCategory.FOOD)
+                .build();
+
+        this.mockMvc.perform(post(BASE_URI)
+                .content(convertDtoToJson(create))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+    }
+    @Test
+    @DisplayName("메뉴 생성 입력으로 카테고리 값이 null이면 예외를 발생한다.")
+    void createMenuWithInvalidCategory() throws Exception {
+        MenuCommandDto.Create create = MenuCommandDto.Create.builder()
+                .name("상품1")
+                .description("설명1")
+                .price(1000)
+                .stockQuantity(15)
+                .menuCategory(null)
+                .build();
+
+        this.mockMvc.perform(post(BASE_URI)
+                        .content(convertDtoToJson(create))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusResponse.resultCode")
+                        .value(ResultCode.INVALID_INPUT.getCode()));
+    }
+
+    private String convertDtoToJson(Object obj) throws JsonProcessingException {
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+        ObjectWriter objectWriter = objectMapper.writer().withDefaultPrettyPrinter();
+
+        return objectWriter.writeValueAsString(obj);
+    }
+
+}

--- a/src/test/java/com/asgs/allimi/menu/service/MenuCommandServiceTest.java
+++ b/src/test/java/com/asgs/allimi/menu/service/MenuCommandServiceTest.java
@@ -1,0 +1,125 @@
+package com.asgs.allimi.menu.service;
+
+import com.asgs.allimi.common.exception.CustomClientException;
+import com.asgs.allimi.common.response.ResultCode;
+import com.asgs.allimi.menu.domain.Menu;
+import com.asgs.allimi.menu.domain.MenuCategory;
+import com.asgs.allimi.menu.dto.MenuCommandDto;
+import com.asgs.allimi.menu.dto.MenuDetailOptionCommandDto;
+import com.asgs.allimi.menu.dto.MenuOptionCommandDto;
+import com.asgs.allimi.menu.repository.MenuRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MenuCommandServiceTest {
+    @Autowired
+    private MenuCommandService menuCommandService;
+    @Autowired
+    private MenuRepository menuRepository;
+
+    @Test
+    @DisplayName("옵션 필드를 제외한 메뉴 데이터 저장에 성공한다.")
+    void createMenu() {
+        // given
+        MenuCommandDto.Create create = MenuCommandDto.Create.builder()
+                .name("상품1")
+                .description("설명1")
+                .price(1000)
+                .stockQuantity(15)
+                .menuCategory(MenuCategory.BREAD)
+                .options(List.of(
+                        MenuOptionCommandDto.Create.builder()
+                                .title("옵션1")
+                                .detailOptions(
+                                        List.of(
+                                                MenuDetailOptionCommandDto.Create.builder()
+                                                        .choice("선택지1")
+                                                        .price(500)
+                                                        .build())
+                                ).build()))
+                .build();
+
+        // when
+        Long menuId = menuCommandService.createMenu(create);
+        Menu menu = menuRepository.findById(menuId).get();
+
+        // then
+        assertEquals("상품1", menu.getName());
+        assertEquals("설명1", menu.getDescription());
+        assertEquals(MenuCategory.BREAD, menu.getCategory());
+        assertEquals(1000, menu.getPrice());
+        assertEquals("옵션1", menu.getMenuOptions().get(0).getTitle());
+        assertEquals(500, menu.getMenuOptions().get(0).getMenuDetailOptions().get(0).getPrice());
+
+        // default value
+        assertEquals(0, menu.getDiscount());
+        assertEquals(0, menu.getSoldCount());
+        assertTrue(menu.isOnSale());
+        assertFalse(menu.isAbleBook());
+    }
+
+    @Test
+    @DisplayName("메뉴 가격이 음수가 되면 예외가 발생한다.")
+    void createMenuWithInvalidPrice() {
+        // given
+        MenuCommandDto.Create create = MenuCommandDto.Create.builder()
+                .name("상품1")
+                .description("설명1")
+                .price(-1000)
+                .stockQuantity(15)
+                .menuCategory(MenuCategory.DRINK)
+                .build();
+
+        // when, then
+        assertThatThrownBy(() -> menuCommandService.createMenu(create))
+                .isInstanceOf(CustomClientException.class)
+                .hasMessage(ResultCode.INVALID_INPUT_MENU_PRICE.getMessage());
+    }
+
+    @Test
+    @DisplayName("메뉴 재고가 음수가 되면 예외가 발생한다.")
+    void createMenuWithInvalidStockQuantity() {
+        // given
+        MenuCommandDto.Create create = MenuCommandDto.Create.builder()
+                .name("상품1")
+                .description("설명1")
+                .price(1000)
+                .stockQuantity(-99)
+                .menuCategory(MenuCategory.DRINK)
+                .build();
+
+        // when, then
+        assertThatThrownBy(() -> menuCommandService.createMenu(create))
+                .isInstanceOf(CustomClientException.class)
+                .hasMessage(ResultCode.INVALID_INPUT_STOCK_QUANTITY.getMessage());
+    }
+
+    @Test
+    @DisplayName("메뉴 할인률이 유효 범위 내에 없다면 예외가 발생한다.")
+    void createMenuWithInvalidDiscount() {
+        // given
+        MenuCommandDto.Create create = MenuCommandDto.Create.builder()
+                .name("상품1")
+                .description("설명1")
+                .price(3000)
+                .stockQuantity(50)
+                .discount(110)
+                .menuCategory(MenuCategory.DRINK)
+                .build();
+
+        // when, then
+        assertThatThrownBy(() -> menuCommandService.createMenu(create))
+                .isInstanceOf(CustomClientException.class)
+                .hasMessage(ResultCode.INVALID_INPUT_DISCOUNT.getMessage());
+    }
+}


### PR DESCRIPTION
## Related Issue
close #15 

- 누락된 EnableJpaAuditing 추가
- Menu 엔티티 stockCount -> stockQuantity로 네이밍 변경
- 입력 Validation에 대한 예외 핸들러 추가
- 임시 시큐리티 인증 삭제
- 메뉴 관련 엔티티 PK 이름 명시
- 메뉴 엔티티 boolean 타입에 대해서는 ColumnDefault에서 직접 값 할당 방식으로 변경

### 메뉴 생성 API 구현
- 필드 검증
  - 가격, 수량, 할인률, 카테고리
- 입력에 옵션이 있다면
  - 옵션 데이터 추가
- 이미지 처리
  - Multipart 요청으로 받아서 미디어 서버로 리다이렉트하는 방식 생각 중
  - 그에 따른 메뉴 이미지 처리도 필요
- 테스트 코드 작성 (Controller, Service)
  - 유효하지 않은 필드 검증 테스트
  - 정상 저장 처리 테스트
  - 디폴트 값 테스트
