### PR TITLE
[MENU] feat: 상세 메뉴 조회 API 구현

### DIFF
--- a/src/main/java/com/asgs/allimi/common/response/ResultCode.java
+++ b/src/main/java/com/asgs/allimi/common/response/ResultCode.java
@@ -16,7 +16,8 @@ public enum ResultCode {
     // 메뉴 클라이언트 에러
     INVALID_INPUT_STOCK_QUANTITY("GS2000", "유효한 재고 수량이 아닙니다."),
     INVALID_INPUT_MENU_PRICE("GS2001", "유효하지 않은 상품 가격입니다."),
-    INVALID_INPUT_DISCOUNT("GS2001", "유효하지 않은 상품 할인률입니다.");
+    INVALID_INPUT_DISCOUNT("GS2002", "유효하지 않은 상품 할인률입니다."),
+    NOT_EXIT_MENU("GS2003", "존재하지 읺는 메뉴입니다.");
     private final String code;
     private final String message;
 

--- a/src/main/java/com/asgs/allimi/menu/controller/MenuQueryController.java
+++ b/src/main/java/com/asgs/allimi/menu/controller/MenuQueryController.java
@@ -1,0 +1,23 @@
+package com.asgs.allimi.menu.controller;
+
+import com.asgs.allimi.common.response.ResponseForm;
+import com.asgs.allimi.menu.dto.MenuQueryDto;
+import com.asgs.allimi.menu.service.MenuQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/menu")
+public class MenuQueryController {
+
+    private final MenuQueryService menuQueryService;
+
+    @GetMapping("/{menuId}")
+    public ResponseForm<MenuQueryDto.Detail> getDetailMenu(@PathVariable("menuId") Long menuId) {
+        return new ResponseForm<>(menuQueryService.getDetailMenu(menuId));
+    }
+}

--- a/src/main/java/com/asgs/allimi/menu/domain/Menu.java
+++ b/src/main/java/com/asgs/allimi/menu/domain/Menu.java
@@ -49,7 +49,10 @@ public class Menu extends BaseEntity {
     private boolean isAbleBook = false;
 
     @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MenuOption> menuOptions = new ArrayList<>();
+    private List<MenuOption> menuOptions;
+
+    @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MenuImage> menuImages = new ArrayList<>();
 
     @Builder
     public Menu(String name, String description, MenuCategory category, int price, int stockQuantity, int discount, boolean isAbleBook) {

--- a/src/main/java/com/asgs/allimi/menu/dto/MenuDetailOptionQueryDto.java
+++ b/src/main/java/com/asgs/allimi/menu/dto/MenuDetailOptionQueryDto.java
@@ -1,0 +1,18 @@
+package com.asgs.allimi.menu.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class MenuDetailOptionQueryDto {
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class DetailOptions{
+        private Long detailOptionId;
+        private String choice;
+        private int price;
+    }
+}

--- a/src/main/java/com/asgs/allimi/menu/dto/MenuOptionQueryDto.java
+++ b/src/main/java/com/asgs/allimi/menu/dto/MenuOptionQueryDto.java
@@ -1,0 +1,21 @@
+package com.asgs.allimi.menu.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class MenuOptionQueryDto {
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Detail {
+        private Long optionId;
+        private String title;
+        private List<MenuDetailOptionQueryDto.DetailOptions> detailOptions;
+    }
+}

--- a/src/main/java/com/asgs/allimi/menu/dto/MenuQueryDto.java
+++ b/src/main/java/com/asgs/allimi/menu/dto/MenuQueryDto.java
@@ -1,0 +1,34 @@
+package com.asgs.allimi.menu.dto;
+
+import com.asgs.allimi.menu.domain.MenuCategory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class MenuQueryDto {
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Detail{
+        private Long menuId;
+        private String name;
+        private String description;
+        private MenuCategory category;
+        private int stockQuantity;
+        private int originalPrice;
+        private int currentPrice;
+        private int discount;
+        private boolean isAbleBook;
+        private List<String> images;
+        private List<MenuOptionQueryDto.Detail> options;
+    }
+
+
+
+
+}

--- a/src/main/java/com/asgs/allimi/menu/service/MenuQueryService.java
+++ b/src/main/java/com/asgs/allimi/menu/service/MenuQueryService.java
@@ -1,0 +1,74 @@
+package com.asgs.allimi.menu.service;
+
+import com.asgs.allimi.common.exception.CustomClientException;
+import com.asgs.allimi.menu.domain.Menu;
+import com.asgs.allimi.menu.domain.MenuImage;
+import com.asgs.allimi.menu.dto.MenuDetailOptionQueryDto;
+import com.asgs.allimi.menu.dto.MenuOptionQueryDto;
+import com.asgs.allimi.menu.dto.MenuQueryDto;
+import com.asgs.allimi.menu.repository.MenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import static com.asgs.allimi.common.response.ResultCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class MenuQueryService {
+    private final MenuRepository menuRepository;
+
+    public MenuQueryDto.Detail getDetailMenu(Long menuId) {
+        Menu menu = getMenuByIdElseThrow(menuId);
+
+        MenuQueryDto.Detail response = MenuQueryDto.Detail.builder()
+                .menuId(menu.getId())
+                .name(menu.getName())
+                .description(menu.getDescription())
+                .category(menu.getCategory())
+                .originalPrice(menu.getPrice())
+                .stockQuantity(menu.getStockQuantity())
+                .discount(menu.getDiscount())
+                .isAbleBook(menu.isAbleBook())
+                .build();
+
+        response.setCurrentPrice(calculateDiscount(menu.getPrice(), menu.getDiscount()));
+
+        if (menu.getMenuOptions() != null) {
+            response.setOptions(
+                    menu.getMenuOptions().stream().map(option ->
+                            MenuOptionQueryDto.Detail.builder()
+                                    .optionId(option.getId())
+                                    .title(option.getTitle())
+                                    .detailOptions(
+                                            option.getMenuDetailOptions()
+                                                    .stream().map(detail ->
+                                                            MenuDetailOptionQueryDto.DetailOptions.builder()
+                                                                    .detailOptionId(detail.getId())
+                                                                    .price(detail.getPrice())
+                                                                    .choice(detail.getChoice())
+                                                                    .build()
+                                                    ).toList()
+                                    ).build()
+                    ).toList()
+            );
+        }
+
+        response.setImages(
+                menu.getMenuImages().stream().map(
+                        (MenuImage::getPath)
+                ).toList()
+        );
+
+        return response;
+    }
+
+    private Menu getMenuByIdElseThrow(Long menuId) {
+        return menuRepository.findById(menuId)
+                .orElseThrow(() -> new CustomClientException(HttpStatus.NOT_FOUND, NOT_EXIT_MENU));
+    }
+
+    private int calculateDiscount(int price, int discount) {
+        return (int) Math.floor((price * (100 - discount)) / 100.0); // 내림
+    }
+}

--- a/src/test/java/com/asgs/allimi/menu/controller/MenuQueryControllerTest.java
+++ b/src/test/java/com/asgs/allimi/menu/controller/MenuQueryControllerTest.java
@@ -1,0 +1,44 @@
+package com.asgs.allimi.menu.controller;
+
+import com.asgs.allimi.menu.domain.Menu;
+import com.asgs.allimi.menu.domain.MenuCategory;
+import com.asgs.allimi.menu.repository.MenuRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class MenuQueryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private MenuRepository menuRepository;
+    private static final String BASE_URI = "/api/v1/menu";
+
+    @Test
+    void getDetailMenu() throws Exception {
+        Menu menu = Menu.builder()
+                .name("테스트상품")
+                .description("설명입니다.")
+                .category(MenuCategory.DRINK)
+                .stockQuantity(20)
+                .price(2000).build();
+        Menu saved = menuRepository.save(menu);
+
+        this.mockMvc.perform(get(BASE_URI + "/" + saved.getId()))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.name").value("테스트상품"));
+    }
+}

--- a/src/test/java/com/asgs/allimi/menu/service/MenuQueryServiceTest.java
+++ b/src/test/java/com/asgs/allimi/menu/service/MenuQueryServiceTest.java
@@ -1,0 +1,150 @@
+package com.asgs.allimi.menu.service;
+
+import com.asgs.allimi.common.exception.CustomClientException;
+import com.asgs.allimi.common.response.ResultCode;
+import com.asgs.allimi.menu.domain.Menu;
+import com.asgs.allimi.menu.domain.MenuCategory;
+import com.asgs.allimi.menu.dto.*;
+import com.asgs.allimi.menu.repository.MenuRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MenuQueryServiceTest {
+    @Autowired
+    private MenuQueryService menuQueryService;
+    @Autowired
+    private MenuCommandService menuCommandService;
+    @Autowired
+    private MenuRepository menuRepository;
+
+    @Test
+    @DisplayName("옵션 없이 저장한 상세 메뉴 조회에 성공한다.")
+    void getDetailMenuWithoutOption() {
+        // given
+        Menu menu = Menu.builder()
+                .name("상품1")
+                .description("설명1")
+                .category(MenuCategory.DRINK)
+                .stockQuantity(20)
+                .price(2000).build();
+        Menu saved = menuRepository.save(menu);
+
+        // when
+        MenuQueryDto.Detail detailMenu = menuQueryService.getDetailMenu(saved.getId());
+
+        // then
+        assertNull(detailMenu.getOptions());
+        assertThat(detailMenu.getImages()).isEmpty();
+        assertEquals("상품1", detailMenu.getName());
+        assertEquals(MenuCategory.DRINK, detailMenu.getCategory());
+        assertThat(detailMenu.getCurrentPrice()).isEqualTo(detailMenu.getOriginalPrice());
+    }
+
+    @Test
+    @DisplayName("옵션과 저장한 상세 메뉴 조회에 성공한다.")
+    void getDetailMenuWithOption() {
+        // given
+        MenuCommandDto.Create create = MenuCommandDto.Create.builder()
+                .name("아메리카노")
+                .description("부드러운 아메리카노")
+                .price(1000)
+                .stockQuantity(15)
+                .menuCategory(MenuCategory.MADE_BEVERAGE)
+                .options(List.of(
+                        MenuOptionCommandDto.Create.builder()
+                                .title("수령방식")
+                                .detailOptions(
+                                        List.of(
+                                                MenuDetailOptionCommandDto.Create.builder()
+                                                        .choice("일회용컵")
+                                                        .price(300)
+                                                        .build(),
+                                                MenuDetailOptionCommandDto.Create.builder()
+                                                        .choice("텀블러")
+                                                        .price(-500)
+                                                        .build())
+                                ).build()))
+                .build();
+        Long menuId = menuCommandService.createMenu(create);
+
+        // when
+        MenuQueryDto.Detail detailMenu = menuQueryService.getDetailMenu(menuId);
+
+        // then
+        assertThat(detailMenu.getName())
+                .isEqualTo("아메리카노");
+        assertThat(detailMenu.getOptions().get(0).getTitle())
+                .isEqualTo("수령방식");
+        assertThat(detailMenu.getOptions().get(0).getDetailOptions())
+                .hasSize(2);
+        assertThat(detailMenu.getOptions().get(0).getDetailOptions().stream().map(MenuDetailOptionQueryDto.DetailOptions::getChoice))
+                .contains("일회용컵", "텀블러");
+    }
+
+    @Test
+    @DisplayName("할인이 적용된 메뉴의 현재 가격을 조회한다.")
+    void getDetailMenuWithDiscount() {
+        // given
+        Menu menu = Menu.builder()
+                .name("상품1")
+                .description("설명1")
+                .category(MenuCategory.DRINK)
+                .stockQuantity(20)
+                .discount(20) // 20%
+                .price(2000)
+                .build();
+        Menu menu2 = Menu.builder()
+                .name("상품1")
+                .description("설명1")
+                .category(MenuCategory.DRINK)
+                .stockQuantity(20)
+                .discount(24) // 24%
+                .price(3600)
+                .build();
+        Menu menu3 = Menu.builder()
+                .name("상품1")
+                .description("설명1")
+                .category(MenuCategory.DRINK)
+                .stockQuantity(20)
+                .discount(17) // 27%
+                .price(3350)
+                .build();
+
+        Menu saved = menuRepository.save(menu);
+        Menu saved2 = menuRepository.save(menu2);
+        Menu saved3 = menuRepository.save(menu3);
+
+        // when
+        MenuQueryDto.Detail detailMenu = menuQueryService.getDetailMenu(saved.getId());
+        MenuQueryDto.Detail detailMenu2 = menuQueryService.getDetailMenu(saved2.getId());
+        MenuQueryDto.Detail detailMenu3 = menuQueryService.getDetailMenu(saved3.getId());
+
+        // then
+        assertThat(detailMenu.getCurrentPrice()).isEqualTo(1600);
+        assertThat(detailMenu2.getCurrentPrice()).isEqualTo(2736);
+        assertThat(detailMenu3.getCurrentPrice()).isEqualTo(2780);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 메뉴 ID로 상세 메뉴 조회 시 예외가 발생한다.")
+    void getDetailMenuWithInvalidMenuId() {
+        // given
+        Long menuId = -1L;
+
+        // when, then
+        assertThatThrownBy(() -> menuQueryService.getDetailMenu(menuId))
+                .isInstanceOf(CustomClientException.class)
+                .hasMessage(ResultCode.NOT_EXIT_MENU.getMessage());
+    }
+
+}


### PR DESCRIPTION
## Related Issue
close #19 

- 입력으로 주어진 메뉴 ID를 통해 상세 메뉴 데이터를 조회
- 응답 바디에 'originalPrice'와 'currentPrice'를 통해 할인적용된 가격까지 제공
- 메뉴 엔티티에 meneOptions 필드에 초기화를 제거함으로써 기본 값을 null로 설정하게끔 변경
  - 초기화를 시키면 null처리를 하지 않으면 빈 배열이 전달되기 때문에 변경
  - 이거나 저거나 똑같긴하다. null 처리를 하거나 빈 배열 이라는 조건문 처리를 해서 응답으로 옵션 데이터를 null로 제공하게끔 하는 것은 같다. 
- 응답 dto를 만들 때 무분별하게 엔티티에서 dto로 변환하는 빌더패턴 사용되는 것이 좋아보이지 않는데, 이를 어디에 종속시켜야할지 분리해야할지 고민이 더 필요해보인다.
- 그리고 할인과 관련해서 할인에 대한 로직을 별도의 서비스로 분리해서 추후에 구현할 포인트 기능과 함께 엮으면 어떨지 고민도 해보고 있다. 
- 테스트 케이스 작성
  - 할인률이 잘 적용되었는지
  - 옵션 유/무에 따른 응답도 잘 받아와지는지
  - 존재하지 않는 메뉴로 조회하면 예외 발생
