### PR TITLE
[MENU] refactor: 메뉴에 대한 할인 처리 로직 분리 리팩토링

### DIFF
--- a/src/main/java/com/asgs/allimi/discount/DiscountService.java
+++ b/src/main/java/com/asgs/allimi/discount/DiscountService.java
@@ -1,0 +1,5 @@
+package com.asgs.allimi.discount;
+
+public interface DiscountService {
+    int calculateDiscountedPrice(int price, int discountFactor);
+}

--- a/src/main/java/com/asgs/allimi/discount/RateDiscountService.java
+++ b/src/main/java/com/asgs/allimi/discount/RateDiscountService.java
@@ -1,0 +1,22 @@
+package com.asgs.allimi.discount;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class RateDiscountService implements DiscountService {
+    private static final double PERCENTAGE = 100.0;
+    private static final int MIN_PERCENTAGE = 1;
+    private static final int MAX_PERCENTAGE = 100;
+
+    @Override
+    public int calculateDiscountedPrice(int price, int discountFactor) {
+        if (isRateInRange(discountFactor)) {
+            return (int) (price * (1 - discountFactor / PERCENTAGE));
+        }
+        return 0;
+    }
+
+    public boolean isRateInRange(int rate) {
+        return rate >= MIN_PERCENTAGE && rate <= MAX_PERCENTAGE;
+    }
+}

--- a/src/main/java/com/asgs/allimi/menu/service/MenuCommandService.java
+++ b/src/main/java/com/asgs/allimi/menu/service/MenuCommandService.java
@@ -1,6 +1,7 @@
 package com.asgs.allimi.menu.service;
 
 import com.asgs.allimi.common.exception.CustomClientException;
+import com.asgs.allimi.discount.RateDiscountService;
 import com.asgs.allimi.menu.domain.Menu;
 import com.asgs.allimi.menu.dto.MenuCommandDto;
 import com.asgs.allimi.menu.repository.MenuRepository;
@@ -17,6 +18,7 @@ import static com.asgs.allimi.common.response.ResultCode.*;
 public class MenuCommandService {
     private final MenuRepository menuRepository;
     private final MenuOptionCommandService menuOptionCommandService;
+    private final RateDiscountService discountService;
 
     public Long createMenu(MenuCommandDto.Create create) {
         validateInput(create);
@@ -42,7 +44,7 @@ public class MenuCommandService {
             throw new CustomClientException(HttpStatus.BAD_REQUEST, INVALID_INPUT_MENU_PRICE);
         }
 
-        if (!isIncludeRange(create.getDiscount())) {
+        if (!discountService.isRateInRange(create.getDiscount())) {
             throw new CustomClientException(HttpStatus.BAD_REQUEST, INVALID_INPUT_DISCOUNT);
         }
     }
@@ -51,7 +53,4 @@ public class MenuCommandService {
         return amount >= 0;
     }
 
-    private boolean isIncludeRange(int amount) {
-        return amount >= 0 && amount <= 100;
-    }
 }

--- a/src/test/java/com/asgs/allimi/discount/RateDiscountServiceTest.java
+++ b/src/test/java/com/asgs/allimi/discount/RateDiscountServiceTest.java
@@ -1,0 +1,21 @@
+package com.asgs.allimi.discount;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RateDiscountServiceTest {
+    private final DiscountService discountService = new RateDiscountService();
+
+    @Test
+    @DisplayName("할인율 서비스 로직 테스트")
+    void rateDiscountTest(){
+        int price = 3350;
+        int rate = 17;
+        int discountedPrice = discountService.calculateDiscountedPrice(price, rate);
+
+        Assertions.assertThat(discountedPrice).isEqualTo(2780);
+    }
+
+}


### PR DESCRIPTION
## Related Issue
close #25 

- 할인에 대한 확장성을 위한 인터페이스 정의
  - 추후에 있을 포인트 기능을 염두
  - 상품 옵션에 대한 처리는 유효한지 고민 해봐야할듯
- 이에 따른 할인 처리 로직 대체